### PR TITLE
Remove the invalid CI information

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,8 +84,6 @@ All examples are deployable in the cloud. Follow these rules to achieve this and
 
 A CI/CD configuration file accompanies each example to ensure its validity as part of the automation pipeline. 
 
-> **NOTE:** For more details on the CI tool, see the [Prow](https://github.com/kyma-project/test-infra/blob/master/prow/README.md) documentation.
-
 ### Acceptance tests
 
 For details on acceptance tests for examples, see the [`acceptance-tests`](tests/README.md) document.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,7 +82,9 @@ All examples are deployable in the cloud. Follow these rules to achieve this and
 
 ### Continuous integration
 
-A CI/CD configuration file accompanies each example to ensure its validity as part of the automation pipeline. However, since CI is temporarily not publicly available, the reviewer must check if the related CI job has completed successfully after running it manually.
+A CI/CD configuration file accompanies each example to ensure its validity as part of the automation pipeline. 
+
+> **NOTE:** For more details on the CI tool, see the [Prow](https://github.com/kyma-project/test-infra/blob/master/prow/README.md) documentation.
 
 ### Acceptance tests
 


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Removed the invalid CI information from the `CONTRIBUTING.md` document
- Added a reference to the Prow documentation 

**Related issue(s)**
See  https://github.com/kyma-project/test-infra/issues/72
