### PR TITLE
removed annotations for side-car injection

### DIFF
--- a/event-email-service/deployment/deployment.yaml
+++ b/event-email-service/deployment/deployment.yaml
@@ -26,8 +26,6 @@ spec:
       labels:
         app: event-email-service
         example: event-email-service
-      annotations:
-        sidecar.istio.io/inject: "true"
     spec:
       containers:
       # replace the repository URL with your own repository (e.g. {DockerID}/event-email-service:0.0.x for Docker Hub).

--- a/event-subscription/lambda/deployment/sample-publisher.yaml
+++ b/event-subscription/lambda/deployment/sample-publisher.yaml
@@ -17,8 +17,6 @@ spec:
       labels:
         app: sample-publisher
         example: event-bus-lambda-subscription
-      annotations:
-        sidecar.istio.io/inject: "true"
     spec:
       containers:
       - name: sample-publisher

--- a/event-subscription/service/example-publisher.yaml
+++ b/event-subscription/service/example-publisher.yaml
@@ -16,8 +16,6 @@ spec:
       labels:
         app: example-publisher
         example: event-bus-service-subscription
-      annotations:
-        sidecar.istio.io/inject: "true"
     spec:
       containers:
       - name: example-publisher

--- a/event-subscription/service/example-subscriber.yaml
+++ b/event-subscription/service/example-subscriber.yaml
@@ -30,8 +30,6 @@ spec:
       labels:
         app: event-email-service
         example: event-bus-service-subscription
-      annotations:
-        sidecar.istio.io/inject: "true"
     spec:
       containers:
         - name: event-email-service

--- a/gateway/service/deployment.yaml
+++ b/gateway/service/deployment.yaml
@@ -27,8 +27,6 @@ spec:
       labels:
         app: http-db-service
         example: gateway
-      annotations:
-        sidecar.istio.io/inject: "true"
     spec:
       containers:
       # replace the repository URL with your own repository (e.g. {DockerID}/http-db-service:0.0.x for Docker Hub).

--- a/http-db-service/deployment/deployment.yaml
+++ b/http-db-service/deployment/deployment.yaml
@@ -27,8 +27,6 @@ spec:
       labels:
         app: http-db-service
         example: http-db-service
-      annotations:
-        sidecar.istio.io/inject: "true"
     spec:
       containers:
       # replace the repository URL with your own repository (e.g. {DockerID}/http-db-service:0.0.x for Docker Hub).

--- a/monitoring-custom-metrics/deployment/deployment.yaml
+++ b/monitoring-custom-metrics/deployment/deployment.yaml
@@ -9,7 +9,6 @@ spec:
     metadata:
       annotations:
         traffic.sidecar.istio.io/includeInboundPorts: "8080"  
-        sidecar.istio.io/inject: "true"
       labels:
         app: sample-metrics
         example: monitoring-custom-metrics

--- a/service-binding/service/deployment/http-db-service.yaml
+++ b/service-binding/service/deployment/http-db-service.yaml
@@ -21,8 +21,6 @@ spec:
     metadata:
       labels:
         example: service-binding
-      annotations:
-        sidecar.istio.io/inject: "true"
     spec:
       containers:
       # replace the repository URL with your own repository (e.g. {DockerID}/http-db-service:0.0.x for Docker Hub).

--- a/tracing/deployment/deployment.yaml
+++ b/tracing/deployment/deployment.yaml
@@ -41,8 +41,6 @@ spec:
       labels:
         app: order-front
         example: tracing
-      annotations:
-        sidecar.istio.io/inject: "true"
     spec:
       containers:
         - name: order-front
@@ -90,8 +88,6 @@ spec:
       labels:
         example: tracing
         app: db-service
-      annotations:
-        sidecar.istio.io/inject: "true"
     spec:
       imagePullSecrets:
       containers:


### PR DESCRIPTION
**Description**
Istio side car injection is enabled by default on any newly created namespace (having env=true label). With that, it is not required to enable it additionally on any deployment. So I removed it from the examples to keep the code focused on the example.
