### PR TITLE
Add an example API for events to http-db-service

### DIFF
--- a/http-db-service/docs/api/api.yaml
+++ b/http-db-service/docs/api/api.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  title: Order service API
+  title: Order service and Events API
   version: "0.0.1"
 paths:
   /orders:
@@ -71,6 +71,23 @@ paths:
           description: Bad request.
         '500':
           description: Internal server error.
+  /events/order/created:
+    post:
+      description: Handle order created event
+      tags:
+        - events orders
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrderCreatedEvent'
+      responses:
+        '200':
+          description: Order created event handled successfully.
+        '400':
+          description: Bad request.
+        '500':
+          description: Internal Server error.
 components:
   schemas:
     Order:
@@ -92,3 +109,11 @@ components:
       type: array
       items:
         $ref: '#/components/schemas/Order'
+    OrderCreatedEvent:
+      type: object
+      properties:
+        orderCode:
+          type: string
+          example: 76272727
+      required:
+        - orderCode

--- a/http-db-service/handler/events/order_created.go
+++ b/http-db-service/handler/events/order_created.go
@@ -1,0 +1,37 @@
+package events
+
+import (
+	"encoding/json"
+	"fmt"
+	log "github.com/Sirupsen/logrus"
+	"github.com/kyma-project/examples/http-db-service/handler/utils"
+	"github.com/kyma-project/examples/http-db-service/internal/repository"
+	"io/ioutil"
+	"net/http"
+)
+
+func HandleOrderCreatedEvent(w http.ResponseWriter, r *http.Request) {
+	b, err := ioutil.ReadAll(r.Body)
+
+	if err != nil {
+		log.Error("error parsing request", err)
+		utils.RespondWithCodeAndMessage(http.StatusInternalServerError, "Internal error.", w)
+		return
+	}
+
+	defer r.Body.Close()
+
+	var event repository.OrderCreatedEvent
+	err = json.Unmarshal(b, &event)
+
+	if err != nil || event.OrderCode == "" {
+		utils.RespondWithCodeAndMessage(http.StatusBadRequest, "Invalid request body, orderCode cannot be empty.", w)
+		return
+	}
+	fmt.Println("handle order create called.")
+
+	log.Infof("Handling event '%+v' with my custom logic..", event)
+	//here add any custom logic such as sending an email, gather insights into purchase.
+
+	w.WriteHeader(http.StatusOK)
+}

--- a/http-db-service/handler/events/order_created.go
+++ b/http-db-service/handler/events/order_created.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	log "github.com/Sirupsen/logrus"
-	"github.com/kyma-project/examples/http-db-service/handler/utils"
+	"github.com/kyma-project/examples/http-db-service/handler/response"
 	"github.com/kyma-project/examples/http-db-service/internal/repository"
 	"io/ioutil"
 	"net/http"
@@ -15,7 +15,7 @@ func HandleOrderCreatedEvent(w http.ResponseWriter, r *http.Request) {
 
 	if err != nil {
 		log.Error("error parsing request", err)
-		utils.RespondWithCodeAndMessage(http.StatusInternalServerError, "Internal error.", w)
+		response.WriteCodeAndMessage(http.StatusInternalServerError, "Internal error.", w)
 		return
 	}
 
@@ -25,7 +25,7 @@ func HandleOrderCreatedEvent(w http.ResponseWriter, r *http.Request) {
 	err = json.Unmarshal(b, &event)
 
 	if err != nil || event.OrderCode == "" {
-		utils.RespondWithCodeAndMessage(http.StatusBadRequest, "Invalid request body, orderCode cannot be empty.", w)
+		response.WriteCodeAndMessage(http.StatusBadRequest, "Invalid request body, orderCode cannot be empty.", w)
 		return
 	}
 	fmt.Println("handle order create called.")

--- a/http-db-service/handler/events/order_created_test.go
+++ b/http-db-service/handler/events/order_created_test.go
@@ -1,0 +1,52 @@
+package events
+
+import (
+	"bytes"
+	"encoding/json"
+	"github.com/gorilla/mux"
+	"github.com/kyma-project/examples/http-db-service/internal/repository"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+const path = "/events/order/created"
+
+func TestHandleOrderCreatedEventSuccess(t *testing.T) {
+	router := mux.NewRouter()
+	router.HandleFunc(path, HandleOrderCreatedEvent).Methods(http.MethodPost)
+
+	ts := httptest.NewServer(router)
+	defer ts.Close()
+
+	event := repository.OrderCreatedEvent{OrderCode: "handle-success"}
+	requestBody := new(bytes.Buffer)
+	json.NewEncoder(requestBody).Encode(event)
+
+	res, err := http.Post(ts.URL+path, "application/json", requestBody)
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusOK, res.StatusCode)
+}
+
+func TestHandleOrderCreatedEventBadPayload(t *testing.T) {
+	router := mux.NewRouter()
+	router.HandleFunc(path, HandleOrderCreatedEvent).Methods(http.MethodPost)
+
+	ts := httptest.NewServer(router)
+	defer ts.Close()
+
+	badEvent := struct {
+		OrderId string
+	}{OrderId: "handle-400"}
+
+	requestBody := new(bytes.Buffer)
+	json.NewEncoder(requestBody).Encode(badEvent)
+
+	res, err := http.Post(ts.URL+path, "application/json", requestBody)
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusBadRequest, res.StatusCode)
+}

--- a/http-db-service/handler/order.go
+++ b/http-db-service/handler/order.go
@@ -2,12 +2,13 @@ package handler
 
 import (
 	"encoding/json"
+	"fmt"
+	"github.com/kyma-project/examples/http-db-service/handler/utils"
 	"io/ioutil"
 	"net/http"
-	"fmt"
 
-	"github.com/gorilla/mux"
 	log "github.com/Sirupsen/logrus"
+	"github.com/gorilla/mux"
 
 	"github.com/kyma-project/examples/http-db-service/internal/repository"
 )
@@ -24,18 +25,13 @@ func NewOrderHandler(repository repository.OrderRepository) Order {
 	return Order{repository}
 }
 
-type errorResponse struct {
-	Status  int    `json:"status"`
-	Message string `json:"message"`
-}
-
 // InsertOrder handles an http request for creating an Order given in JSON format.
 // The handler also validates the Order payload fields and handles duplicate entry or unexpected errors.
 func (orderHandler Order) InsertOrder(w http.ResponseWriter, r *http.Request) {
 	b, err := ioutil.ReadAll(r.Body)
 	if err != nil {
 		log.Error("Error parsing request.", err)
-		respondWithCodeAndMessage(http.StatusInternalServerError, "Internal error.", w)
+		utils.RespondWithCodeAndMessage(http.StatusInternalServerError, "Internal error.", w)
 		return
 	}
 
@@ -43,7 +39,7 @@ func (orderHandler Order) InsertOrder(w http.ResponseWriter, r *http.Request) {
 	var order repository.Order
 	err = json.Unmarshal(b, &order)
 	if err != nil || order.OrderId == "" || order.Total == 0 {
-		respondWithCodeAndMessage(http.StatusBadRequest, "Invalid request body, orderId / total fields cannot be empty.", w)
+		utils.RespondWithCodeAndMessage(http.StatusBadRequest, "Invalid request body, orderId / total fields cannot be empty.", w)
 		return
 	}
 	if order.Namespace == "" {
@@ -54,14 +50,14 @@ func (orderHandler Order) InsertOrder(w http.ResponseWriter, r *http.Request) {
 	err = orderHandler.repository.InsertOrder(order)
 
 	switch err {
-		case nil:
-			w.WriteHeader(http.StatusCreated)
-		case repository.ErrDuplicateKey:
-			respondWithCodeAndMessage(http.StatusConflict, fmt.Sprintf("Order %s already exists.", order.OrderId), w)
-		default:
-			log.Error(fmt.Sprintf("Error inserting order: '%+v'", order), err)
-			respondWithCodeAndMessage(http.StatusInternalServerError, "Internal error.", w)
-   }
+	case nil:
+		w.WriteHeader(http.StatusCreated)
+	case repository.ErrDuplicateKey:
+		utils.RespondWithCodeAndMessage(http.StatusConflict, fmt.Sprintf("Order %s already exists.", order.OrderId), w)
+	default:
+		log.Error(fmt.Sprintf("Error inserting order: '%+v'", order), err)
+		utils.RespondWithCodeAndMessage(http.StatusInternalServerError, "Internal error.", w)
+	}
 }
 
 // GetOrders handles an http request for retrieving all Orders from all namespaces.
@@ -72,13 +68,13 @@ func (orderHandler Order) GetOrders(w http.ResponseWriter, r *http.Request) {
 	orders, err := orderHandler.repository.GetOrders()
 	if err != nil {
 		log.Error("Error retrieving orders.", err)
-		respondWithCodeAndMessage(http.StatusInternalServerError, "Internal error.", w)
+		utils.RespondWithCodeAndMessage(http.StatusInternalServerError, "Internal error.", w)
 		return
 	}
 
 	if err = respondOrders(orders, w); err != nil {
 		log.Error("Error sending orders response.", err)
-		respondWithCodeAndMessage(http.StatusInternalServerError, "Internal error.", w)
+		utils.RespondWithCodeAndMessage(http.StatusInternalServerError, "Internal error.", w)
 		return
 	}
 }
@@ -88,7 +84,7 @@ func (orderHandler Order) GetOrders(w http.ResponseWriter, r *http.Request) {
 func (orderHandler Order) GetNamespaceOrders(w http.ResponseWriter, r *http.Request) {
 	ns, exists := mux.Vars(r)["namespace"]
 	if !exists {
-		respondWithCodeAndMessage(http.StatusBadRequest, "No namespace provided.", w)
+		utils.RespondWithCodeAndMessage(http.StatusBadRequest, "No namespace provided.", w)
 		return
 	}
 
@@ -97,13 +93,13 @@ func (orderHandler Order) GetNamespaceOrders(w http.ResponseWriter, r *http.Requ
 	orders, err := orderHandler.repository.GetNamespaceOrders(ns)
 	if err != nil {
 		log.Error("Error retrieving orders.", err)
-		respondWithCodeAndMessage(http.StatusInternalServerError, "Internal error.", w)
+		utils.RespondWithCodeAndMessage(http.StatusInternalServerError, "Internal error.", w)
 		return
 	}
 
 	if err = respondOrders(orders, w); err != nil {
 		log.Error("Error sending orders response.", err)
-		respondWithCodeAndMessage(http.StatusInternalServerError, "Internal error.", w)
+		utils.RespondWithCodeAndMessage(http.StatusInternalServerError, "Internal error.", w)
 		return
 	}
 }
@@ -128,7 +124,7 @@ func (orderHandler Order) DeleteOrders(w http.ResponseWriter, r *http.Request) {
 
 	if err := orderHandler.repository.DeleteOrders(); err != nil {
 		log.Error("Error deleting orders.", err)
-		respondWithCodeAndMessage(http.StatusInternalServerError, "Internal error.", w)
+		utils.RespondWithCodeAndMessage(http.StatusInternalServerError, "Internal error.", w)
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
@@ -138,24 +134,15 @@ func (orderHandler Order) DeleteOrders(w http.ResponseWriter, r *http.Request) {
 func (orderHandler Order) DeleteNamespaceOrders(w http.ResponseWriter, r *http.Request) {
 	ns, exists := mux.Vars(r)["namespace"]
 	if !exists {
-		respondWithCodeAndMessage(http.StatusBadRequest, "No namespace provided.", w)
+		utils.RespondWithCodeAndMessage(http.StatusBadRequest, "No namespace provided.", w)
 		return
 	}
 
 	log.Debugf("Deleting orders in namespace %s\n", ns)
 	if err := orderHandler.repository.DeleteNamespaceOrders(ns); err != nil {
 		log.Errorf("Deleting orders in namespace %s\n. %s", ns, err)
-		respondWithCodeAndMessage(http.StatusInternalServerError, "Internal error.", w)
+		utils.RespondWithCodeAndMessage(http.StatusInternalServerError, "Internal error.", w)
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
-}
-
-func respondWithCodeAndMessage(code int, msg string, w http.ResponseWriter) {
-	w.Header().Set("Content-Type", "application/json;charset=UTF-8")
-	w.WriteHeader(code)
-	response := errorResponse{code, msg}
-	if err := json.NewEncoder(w).Encode(response); err != nil {
-		log.Error("Error sending response", err)
-	}
 }

--- a/http-db-service/handler/order_test.go
+++ b/http-db-service/handler/order_test.go
@@ -2,11 +2,10 @@ package handler
 
 import (
 	"bytes"
-	"fmt"
-	"github.com/kyma-project/examples/http-db-service/handler/utils"
-
 	"encoding/json"
 	"errors"
+	"fmt"
+	responseObj "github.com/kyma-project/examples/http-db-service/handler/response"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -61,7 +60,7 @@ func TestCreateOrderValidation(t *testing.T) {
 	require.NoError(t, err)
 
 	// then
-	var m utils.ErrorResponse
+	var m responseObj.Body
 
 	b, err := ioutil.ReadAll(res.Body)
 	require.NoError(t, err)
@@ -102,7 +101,7 @@ func TestCreateOrderConflict(t *testing.T) {
 	require.NoError(t, err)
 
 	// then
-	var errorResponse utils.ErrorResponse
+	var errorResponse responseObj.Body
 
 	responseBody, err := ioutil.ReadAll(response.Body)
 	require.NoError(t, err)
@@ -145,7 +144,7 @@ func TestOrderCreateInternalError(t *testing.T) {
 	require.NoError(t, err)
 	defer response.Body.Close()
 
-	var errorResponse utils.ErrorResponse
+	var errorResponse responseObj.Body
 	json.Unmarshal(responseBody, &errorResponse)
 
 	assert.Equal(t, 500, errorResponse.Status)
@@ -248,7 +247,7 @@ func TestGetOrderInternalError(t *testing.T) {
 	require.NoError(t, err)
 
 	// then
-	var m utils.ErrorResponse
+	var m responseObj.Body
 
 	b, err := ioutil.ReadAll(res.Body)
 	require.NoError(t, err)
@@ -330,7 +329,7 @@ func TestDeletingOrdersInternalError(t *testing.T) {
 
 	// then
 	require.NoError(t, err)
-	var m utils.ErrorResponse
+	var m responseObj.Body
 
 	b, err := ioutil.ReadAll(res.Body)
 	require.NoError(t, err)

--- a/http-db-service/handler/order_test.go
+++ b/http-db-service/handler/order_test.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"bytes"
 	"fmt"
+	"github.com/kyma-project/examples/http-db-service/handler/utils"
 
 	"encoding/json"
 	"errors"
@@ -60,7 +61,7 @@ func TestCreateOrderValidation(t *testing.T) {
 	require.NoError(t, err)
 
 	// then
-	var m errorResponse
+	var m utils.ErrorResponse
 
 	b, err := ioutil.ReadAll(res.Body)
 	require.NoError(t, err)
@@ -101,7 +102,7 @@ func TestCreateOrderConflict(t *testing.T) {
 	require.NoError(t, err)
 
 	// then
-	var errorResponse errorResponse
+	var errorResponse utils.ErrorResponse
 
 	responseBody, err := ioutil.ReadAll(response.Body)
 	require.NoError(t, err)
@@ -144,7 +145,7 @@ func TestOrderCreateInternalError(t *testing.T) {
 	require.NoError(t, err)
 	defer response.Body.Close()
 
-	var errorResponse errorResponse
+	var errorResponse utils.ErrorResponse
 	json.Unmarshal(responseBody, &errorResponse)
 
 	assert.Equal(t, 500, errorResponse.Status)
@@ -247,7 +248,7 @@ func TestGetOrderInternalError(t *testing.T) {
 	require.NoError(t, err)
 
 	// then
-	var m errorResponse
+	var m utils.ErrorResponse
 
 	b, err := ioutil.ReadAll(res.Body)
 	require.NoError(t, err)
@@ -329,7 +330,7 @@ func TestDeletingOrdersInternalError(t *testing.T) {
 
 	// then
 	require.NoError(t, err)
-	var m errorResponse
+	var m utils.ErrorResponse
 
 	b, err := ioutil.ReadAll(res.Body)
 	require.NoError(t, err)

--- a/http-db-service/handler/response/response.go
+++ b/http-db-service/handler/response/response.go
@@ -1,4 +1,4 @@
-package utils
+package response
 
 import (
 	"encoding/json"
@@ -6,15 +6,15 @@ import (
 	"net/http"
 )
 
-type ErrorResponse struct {
+type Body struct {
 	Status  int    `json:"status"`
 	Message string `json:"message"`
 }
 
-func RespondWithCodeAndMessage(code int, msg string, w http.ResponseWriter) {
+func WriteCodeAndMessage(code int, msg string, w http.ResponseWriter) {
 	w.Header().Set("Content-Type", "application/json;charset=UTF-8")
 	w.WriteHeader(code)
-	response := ErrorResponse{code, msg}
+	response := Body{code, msg}
 	if err := json.NewEncoder(w).Encode(response); err != nil {
 		log.Error("Error sending response", err)
 	}

--- a/http-db-service/handler/utils/utils.go
+++ b/http-db-service/handler/utils/utils.go
@@ -1,0 +1,21 @@
+package utils
+
+import (
+	"encoding/json"
+	log "github.com/Sirupsen/logrus"
+	"net/http"
+)
+
+type ErrorResponse struct {
+	Status  int    `json:"status"`
+	Message string `json:"message"`
+}
+
+func RespondWithCodeAndMessage(code int, msg string, w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "application/json;charset=UTF-8")
+	w.WriteHeader(code)
+	response := ErrorResponse{code, msg}
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		log.Error("Error sending response", err)
+	}
+}

--- a/http-db-service/internal/repository/api.go
+++ b/http-db-service/internal/repository/api.go
@@ -23,3 +23,7 @@ type OrderRepository interface {
 
 // ErrDuplicateKey is thrown when there is an attempt to create an order with an OrderId which already is used.
 var ErrDuplicateKey = errors.New("Duplicate key")
+
+type OrderCreatedEvent struct {
+	OrderCode string `json:"orderCode"`
+}


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Add a new path `/events/order/created`
- Updated the server to add new handler

**Related issue(s)**
See also https://github.com/kyma-project/kyma/issues/3960
