### PR TITLE
Change eventing publish urls to the new ones

### DIFF
--- a/event-subscription/lambda/README.md
+++ b/event-subscription/lambda/README.md
@@ -86,7 +86,7 @@ kubeless get-server-config
         ```bash
         curl -i \
         -H "Content-Type: application/json" \
-        -X POST http://event-bus-publish.kyma-system:8080/v1/events \
+        -X POST http://event-publish-service.kyma-system:8080/v1/events \
         -d '{"source-id": "external-application", "event-type": "hello", "event-type-version": "v1", "event-time": "2018-11-02T22:08:41+00:00", "data": { "order-number": 123 }}'
         ```
 

--- a/event-subscription/service/README.md
+++ b/event-subscription/service/README.md
@@ -10,8 +10,8 @@ Kyma comes with the NATS Streaming messaging cluster. Instead of interacting wit
 
 Access the Event publishing API from the cluster through the `8080` port on the following hostnames:
 
-* `event-bus-publish.kyma-system`
-* `event-bus-publish.kyma-system.svc.cluster.local`
+* `event-publish-service.kyma-system`
+* `event-publish-service.kyma-system.svc.cluster.local`
 
 ## Prerequisites
 
@@ -70,13 +70,13 @@ Access the Event publishing API from the cluster through the `8080` port on the 
     ```bash
     curl -i \
         -H "Content-Type: application/json" \
-        -X POST http://event-bus-publish.kyma-system:8080/v1/events \
+        -X POST http://event-publish-service.kyma-system:8080/v1/events \
         -d '{"source-id": "external-application", "event-type": "test-event-bus", "event-type-version": "v1", "event-time": "2018-11-02T22:08:41+00:00", "data": {"event":{"customer":{"customerID": "1234", "uid": "rick.sanchez@mail.com"}}}}'
 
     # or use the fully-qualified Event publishing API service name
     curl -i \
         -H "Content-Type: application/json" \
-        -X POST http://event-bus-publish.kyma-system.svc.cluster.local:8080/v1/events \
+        -X POST http://event-publish-service.kyma-system.svc.cluster.local:8080/v1/events \
         -d '{"source-id": "external-application", "event-type": "test-event-bus", "event-type-version": "v1", "event-time": "2018-11-02T22:08:41+00:00", "data": {"event":{"customer":{"customerID": "1234", "uid": "rick.sanchez@mail.com"}}}}'
     ```
     > **NOTE:** To send multiple Events, change the `orderCode` to have a unique value for each POST request.

--- a/examples-chart/templates/tests/event-subscription/lambda/Pod.yaml
+++ b/examples-chart/templates/tests/event-subscription/lambda/Pod.yaml
@@ -21,7 +21,7 @@ spec:
         cd event-subscription/lambda &&
         kubectl apply -f deployment/sample-publisher.yaml -n $KYMA_EXAMPLE_ENV &&
         sleep 10 &&
-        kubectl exec -n $KYMA_EXAMPLE_ENV $(kubectl get pods -n $KYMA_EXAMPLE_ENV -l app=sample-publisher --output=jsonpath={.items..metadata.name}) -c sample-publisher -- curl -i -H "Content-Type: application/json" -X POST http://event-bus-publish.kyma-system:8080/v1/events -d ''{"source-id": "external-application", "event-type": "hello", "event-type-version": "v1", "event-time": "2018-11-02T22:08:41+00:00", "data": { "order-number": 123 }}''
+        kubectl exec -n $KYMA_EXAMPLE_ENV $(kubectl get pods -n $KYMA_EXAMPLE_ENV -l app=sample-publisher --output=jsonpath={.items..metadata.name}) -c sample-publisher -- curl -i -H "Content-Type: application/json" -X POST http://event-publish-service.kyma-system:8080/v1/events -d ''{"source-id": "external-application", "event-type": "hello", "event-type-version": "v1", "event-time": "2018-11-02T22:08:41+00:00", "data": { "order-number": 123 }}''
         ']
       resources:
         limits:


### PR DESCRIPTION
Description
w.r.t https://github.com/kyma-project/kyma/pull/4956 certain components from the event-bus have been refactores and this PR proposes changes in the corresponding example references

Changes proposed in this pull request:

- Update event-bus-publish.kyma-system:8080 => event-publish-service.kyma-system:8080