### PR TITLE
Update Examples documentation CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -14,7 +14,7 @@
 /orders-service/ @m00g3n @aerfio @pPrecel @magicmatatjahu
 
 # All .md files
-*.md @kazydek @bszwarc @klaudiagrz @mmitoraj @majakurcius @alexandra-simeonova
+*.md @kazydek @klaudiagrz @mmitoraj @majakurcius @alexandra-simeonova @superojla
 
 # Config file for MILV - milv.config.yaml
 milv.config.yaml @m00g3n @aerfio @pPrecel @magicmatatjahu


### PR DESCRIPTION
**Description**

Since Barbara Sz. (@bszwarc) left us in September and is no longer an active contributor, she should be removed from CODEOWNERS.  
At the same time, Justyna Sz. (@superojla) joined us in September and has been contributing to Kyma documentation, so it's time to add her to CODEOWNERS. 

Changes proposed in this pull request:

- Remove @bszwarc from documentation CODEOWNERS
- Add @superojla to documentation CODEOWNERS