### PR TITLE
Remove kazydek, superojla, and bszwarc from CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,7 +5,7 @@
 # For more details, read the following article on GitHub: https://help.github.com/articles/about-codeowners/.
 
 # These are the default owners for the whole content of the `examples` repository. The default owners are automatically added as reviewers when you open a pull request, unless different owners are specified in the file.
-* @a-thaler @clebs @suleymanakbas91 @lilitgh @bszwarc @rakesh-garimella @hisarbalik
+* @a-thaler @clebs @suleymanakbas91 @lilitgh @rakesh-garimella @hisarbalik
 
 # Service binding example
 /service-binding/ @Abd4llA @joek @rakesh-garimella @venturasr @lilitgh @k15r @nachtmaar @anishj0shi @montaro @abbi-gaurav @marcobebway @radufa @sayanh
@@ -14,7 +14,7 @@
 /orders-service/ @m00g3n @aerfio @pPrecel @magicmatatjahu
 
 # All .md files
-*.md @kazydek @klaudiagrz @mmitoraj @majakurcius @alexandra-simeonova @superojla
+*.md @klaudiagrz @mmitoraj @majakurcius @alexandra-simeonova @NHingerl
 
 # Config file for MILV - milv.config.yaml
 milv.config.yaml @m00g3n @aerfio @pPrecel @magicmatatjahu


### PR DESCRIPTION
**Description**

As Karolina, Justyna and Basia are no longer active contributors to the project, they must be removed from the CODEOWNERS. 

Changes proposed in this pull request:

- Remove @kazydek, @superojla, and @bszwarc from CODEOWNERS