### PR TITLE
Add Grzegorz as a documentation CODEOWNER in Examples

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -14,7 +14,7 @@
 /orders-service/ @m00g3n @aerfio @pPrecel @magicmatatjahu
 
 # All .md files
-*.md @klaudiagrz @mmitoraj @majakurcius @alexandra-simeonova @NHingerl
+*.md @klaudiagrz @mmitoraj @majakurcius @alexandra-simeonova @NHingerl @grego952
 
 # Config file for MILV - milv.config.yaml
 milv.config.yaml @m00g3n @aerfio @pPrecel @magicmatatjahu


### PR DESCRIPTION
**Description**

As @grego952 has been working with Kyma for over 3 months as a Technical Writer and has gained expertise in this domain, he should be added to the documentation CODEOWNERS.

Changes proposed in this pull request:

- Add @grego952 to Examples documentation CODEOWNERS

**Related issue**
[#13077 ](https://github.com/kyma-project/kyma/issues/13077)
