### PR TITLE
removed unneeded namespace and label from monitoring example

### DIFF
--- a/monitoring-custom-metrics/deployment/service-monitor.yaml
+++ b/monitoring-custom-metrics/deployment/service-monitor.yaml
@@ -3,9 +3,8 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: metrics
-  namespace: kyma-system
   labels:
-    prometheus: monitoring
+    app: sample-metrics
     example: monitoring-custom-metrics
 spec:
   selector:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- A servicemonitor can be placed in any namespace
- The prometheus label is not required anymore on a servicemonitor
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
