### PR TITLE
Fix the broken link to the README.md template

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ In addition to the general [naming guidelines](https://github.com/kyma-project/c
 
 This file type contains information about what an example illustrates, and the instructions on how to run it. Each example in this repository requires a `README.md` document.
 
-To create new `README.md` documents for new examples, use the [template](https://github.com/kyma-project/community/blob/main/templates/repository-template/README.md) provided.
+To create new `README.md` documents for new examples, use the [template](https://github.com/kyma-project/template-repository/blob/main/README.md) provided.
 Do not change the names or the order of the main sections in the `README.md` documents. However, you can create subsections to adjust each `README.md` document to the example's specific requirements. See the example of a [README.md](http-db-service/README.md) document.
 
 Find all `README.md` documents listed in the **List of examples** section in the main [README.md](README.md) document. When you create a new `README.md` document, add a new entry to the **List of examples** table. Follow these steps:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Since we changed the way how to [set up a new repository in Kyma](https://kyma-project.io/community/guidelines/repository-guidelines/01-new-repository-settings), some links and sections became outdated. This PR fixes a broken link to the README.md template.

Changes proposed in this pull request:

- Fix the broken link to the README.md template

