### PR TITLE
Use alpine to exec sh in e2e tests

### DIFF
--- a/orders-service/Dockerfile
+++ b/orders-service/Dockerfile
@@ -28,7 +28,7 @@ FROM alpine:latest as certs
 RUN apk --update add ca-certificates
 
 # result container
-FROM scratch
+FROM alpine:latest
 
 LABEL source = git@github.com:kyma-project/examples.git
 


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- use alpine to be able to exec sh in the resulting pod

**Related issue(s)**
https://github.com/kyma-project/kyma/issues/13872