### PR TITLE
Reflect changes in cloudevents api

### DIFF
--- a/incluster_eventing/src/emitter-fn/config.yaml
+++ b/incluster_eventing/src/emitter-fn/config.yaml
@@ -2,11 +2,10 @@ name: event-emitter
 namespace: default
 runtime: nodejs16
 source:
-    sourceType: git
-    url: https://github.com/kwiatekus/examples.git
-    repository: kyma-examples-repo
-    reference: improve-eventing-example
-    baseDir: /incluster_eventing/src/emitter-fn/
+  url: https://github.com/kwiatekus/examples.git
+  repository: kyma-examples-repo
+  reference: reflect-changes-in-cloudevents-api
+  baseDir: /incluster_eventing/src/emitter-fn/
 apiRules:
     - name: incoming-http-trigger
       service:

--- a/incluster_eventing/src/emitter-fn/config.yaml
+++ b/incluster_eventing/src/emitter-fn/config.yaml
@@ -2,10 +2,11 @@ name: event-emitter
 namespace: default
 runtime: nodejs16
 source:
-  url: https://github.com/kwiatekus/examples.git
-  repository: kyma-examples-repo
-  reference: reflect-changes-in-cloudevents-api
-  baseDir: /incluster_eventing/src/emitter-fn/
+    sourceType: git
+    url: https://github.com/kwiatekus/examples.git
+    repository: kyma-examples-repo
+    reference: reflect-changes-in-cloudevents-api
+    baseDir: /incluster_eventing/src/emitter-fn/
 apiRules:
     - name: incoming-http-trigger
       service:

--- a/incluster_eventing/src/emitter-fn/handler.js
+++ b/incluster_eventing/src/emitter-fn/handler.js
@@ -1,20 +1,22 @@
-const { v4: uuidv4 } = require('uuid');
 const { SpanStatusCode } = require("@opentelemetry/api/build/src/trace/status");
 
 module.exports = {
     main: async function (event, context) {
         let sanitisedData = sanitise(event.data)
 
-        const msgId = uuidv4();
         const eventType = "sap.kyma.custom.acme.payload.sanitised.v1";
         const eventSource = "kyma";
 
-        var eventOut=event.buildResponseCloudEvent(msgId,eventType,sanitisedData);
-        eventOut.source=eventSource;
-        eventOut.specversion="1.0";
+        //optional cloud event params
+        const eventtypeversion = "v1";
+        const datacontenttype = "application/json";
 
         const span = event.tracer.startSpan('call-to-kyma-eventing');
-        return await event.publishCloudEvent(eventOut)
+        
+        // you can pass additional cloudevents attributes  
+        // return await event.emitCloudEvent(eventType, eventSource, sanitisedData, {eventtypeversion, datacontenttype})
+        
+        return await event.emitCloudEvent(eventType, eventSource, sanitisedData)
             .then(resp => {
                 if(resp.status!==204){
                     throw new Error("Unexpected response from eventing proxy");
@@ -22,7 +24,6 @@ module.exports = {
                 span.addEvent("Event sent");
                 span.setAttribute("event-type", eventType);
                 span.setAttribute("event-source", eventSource);
-                span.setAttribute("event-id", msgId);
                 span.setStatus({code: SpanStatusCode.OK});
                 return "Event sent";
             }).catch(err=> {
@@ -30,7 +31,7 @@ module.exports = {
                 span.setStatus({
                     code: SpanStatusCode.ERROR,
                     message: err.message,
-                  });
+                });
                 return err.message;
             }).finally(()=>{
                 span.end();

--- a/incluster_eventing/src/emitter-fn/handler.js
+++ b/incluster_eventing/src/emitter-fn/handler.js
@@ -18,9 +18,7 @@ module.exports = {
         
         return await event.emitCloudEvent(eventType, eventSource, sanitisedData)
             .then(resp => {
-                if(resp.status!==204){
-                    throw new Error("Unexpected response from eventing proxy");
-                }
+                console.log(resp.status);
                 span.addEvent("Event sent");
                 span.setAttribute("event-type", eventType);
                 span.setAttribute("event-source", eventSource);

--- a/incluster_eventing/src/emitter-fn/package.json
+++ b/incluster_eventing/src/emitter-fn/package.json
@@ -2,7 +2,6 @@
   "name": "sanitise-fn",
   "version": "0.0.1",
   "dependencies": {
-    "uuidv4": "6.2.12",
     "@opentelemetry/api": "^1.0.4"
   }
 }

--- a/incluster_eventing/src/receiver-fn/config.yaml
+++ b/incluster_eventing/src/receiver-fn/config.yaml
@@ -5,7 +5,7 @@ source:
     sourceType: git
     url: https://github.com/kwiatekus/examples.git
     repository: kyma-examples-repo
-    reference: improve-eventing-example
+    reference: reflect-changes-in-cloudevents-api
     baseDir: /incluster_eventing/src/receiver-fn/
 subscriptions:
     - name: event-receiver


### PR DESCRIPTION
**Description**
Updates in cluster eventing example to reflect the new cloud-events api in nodejs runtimes 

**Related issue(s)**
Depends on https://github.com/kyma-project/kyma/pull/16116