### PR TITLE
Exclude system namespace from admission webhooks in kube prometheus stack

### DIFF
--- a/prometheus/README.md
+++ b/prometheus/README.md
@@ -60,12 +60,12 @@ The provided `values.yaml` covers the following adjustments:
 - Client certificate injection to support scraping of workload secured with Istio strict mTLS
 - Active scraping of workload annotated with prometheus.io/scrape
 
-    >**Note:** If the adminssion webhooks are also being installed then these webhooks should exclude resources being installed in the `kyma-system` namespace. This can be done in the following way:
-    >    -  Add exclusion of `kyma-system` namespace to mutating webhook
+    >**Note:** If the admission webhooks are also being installed, then these webhooks must exclude resources being installed in the `kyma-system` Namespace. This can be done in the following way:
+    >    -  Add exclusion of the `kyma-system` Namespace to mutating webhook:
     >        ```bash
     >           kubectl -n kyma-system edit mutatingwebhookconfigurations ${HELM_RELEASE}-kube-prometheus-admission
     >        ```
-    >        Exclude `kyma-system` namespace by adding `namespaceSelector`
+    >        Exclude the `kyma-system` Namespace by adding `namespaceSelector`:
     >        ```yaml
     >            namespaceSelector:
     >              matchExpressions:
@@ -74,11 +74,11 @@ The provided `values.yaml` covers the following adjustments:
     >                values:
     >                  - "kyma-system"
     >        ```
-    >   - Add exclusion of `kyma-system` namespace to validationg webhook
+    >   - Add exclusion of the `kyma-system` Namespace to validating webhook:
     >        ```bash
     >         kubectl -n kyma-system edit validatingwebhookconfigurations ${HELM_RELEASE}-kube-prometheus-admission
     >        ```
-    >        Exclude `kyma-system` namespace by adding `namespaceSelector`
+    >        Exclude the `kyma-system` Namespace by adding `namespaceSelector`:
     >        ```yaml
     >            namespaceSelector:
     >              matchExpressions:

--- a/prometheus/README.md
+++ b/prometheus/README.md
@@ -68,11 +68,11 @@ The provided `values.yaml` covers the following adjustments:
     >        Exclude `kyma-system` namespace by adding `namespaceSelector`
     >        ```yaml
     >            namespaceSelector:
-    >            matchExpressions:
-    >                - key: kubernetes.io/metadata.name
+    >              matchExpressions:
+    >              - key: kubernetes.io/metadata.name
     >                operator: NotIn
     >                values:
-    >                    - "kyma-system"
+    >                  - "kyma-system"
     >        ```
     >   - Add exclusion of `kyma-system` namespace to `validationgwebhook`
     >        ```bash
@@ -81,11 +81,11 @@ The provided `values.yaml` covers the following adjustments:
     >        Exclude `kyma-system` namespace by adding `namespaceSelector`
     >        ```yaml
     >            namespaceSelector:
-    >            matchExpressions:
-    >                - key: kubernetes.io/metadata.name
+    >              matchExpressions:
+    >              - key: kubernetes.io/metadata.name
     >                operator: NotIn
     >                values:
-    >                    - "kyma-system"
+    >                  - "kyma-system"
     >        ```  
 
        

--- a/prometheus/README.md
+++ b/prometheus/README.md
@@ -60,8 +60,8 @@ The provided `values.yaml` covers the following adjustments:
 - Client certificate injection to support scraping of workload secured with Istio strict mTLS
 - Active scraping of workload annotated with prometheus.io/scrape
 
-    >**Note:** If the `adminssion webhooks` are also being installed then these webhooks should exclude resources being installed in the `kyma-system` namespace. This can be done in the following way:
-    >    -  Add exclusion of `kyma-system` namespace to `mutatingwebhook`
+    >**Note:** If the adminssion webhooks are also being installed then these webhooks should exclude resources being installed in the `kyma-system` namespace. This can be done in the following way:
+    >    -  Add exclusion of `kyma-system` namespace to mutating webhook
     >        ```bash
     >           kubectl -n kyma-system edit mutatingwebhookconfigurations ${HELM_RELEASE}-kube-prometheus-admission
     >        ```
@@ -74,7 +74,7 @@ The provided `values.yaml` covers the following adjustments:
     >                values:
     >                  - "kyma-system"
     >        ```
-    >   - Add exclusion of `kyma-system` namespace to `validationgwebhook`
+    >   - Add exclusion of `kyma-system` namespace to validationg webhook
     >        ```bash
     >         kubectl -n kyma-system edit validatingwebhookconfigurations ${HELM_RELEASE}-kube-prometheus-admission
     >        ```

--- a/prometheus/README.md
+++ b/prometheus/README.md
@@ -60,6 +60,34 @@ The provided `values.yaml` covers the following adjustments:
 - Client certificate injection to support scraping of workload secured with Istio strict mTLS
 - Active scraping of workload annotated with prometheus.io/scrape
 
+3. If the `adminssion webhooks` are also being installed then these webhooks should exclude resources being installed in the `kyma-system` namespace. This can be done in the following way:
+  -  Add exclusion of `kyma-system` namespace to `mutatingwebhook`
+     ```bash
+        kubectl -n kyma-system edit mutatingwebhookconfigurations ${HELM_RELEASE}-kube-prometheus-admission
+     ```
+     Exclude `kyma-system` namespace by adding `namespaceSelector`
+     ```yaml
+         namespaceSelector:
+           matchExpressions:
+            - key: kubernetes.io/metadata.name
+              operator: NotIn
+              values:
+                - "kyma-system"
+     ```
+  - Add exclusion of `kyma-system` namespace to `validationgwebhook`
+    ```bash
+        kubectl -n kyma-system edit validatingwebhookconfigurations ${HELM_RELEASE}-kube-prometheus-admission
+     ```
+     Exclude `kyma-system` namespace by adding `namespaceSelector`
+     ```yaml
+         namespaceSelector:
+           matchExpressions:
+            - key: kubernetes.io/metadata.name
+              operator: NotIn
+              values:
+                - "kyma-system"
+     ```
+        
 ### Activate scraping of Istio metrics & Grafana dashboards
 
 1. To configure Prometheus for scraping of the Istio-specific metrics from any istio-proxy running in the cluster, deploy a PodMonitor, which scrapes any Pod that has a port with name `.*-envoy-prom` exposed.

--- a/prometheus/README.md
+++ b/prometheus/README.md
@@ -60,34 +60,35 @@ The provided `values.yaml` covers the following adjustments:
 - Client certificate injection to support scraping of workload secured with Istio strict mTLS
 - Active scraping of workload annotated with prometheus.io/scrape
 
-    >**Note** If the `adminssion webhooks` are also being installed then these webhooks should exclude resources being installed in the `kyma-system` namespace. This can be done in the following way:
-        -  Add exclusion of `kyma-system` namespace to `mutatingwebhook`
-            ```bash
-                kubectl -n kyma-system edit mutatingwebhookconfigurations ${HELM_RELEASE}-kube-prometheus-admission
-            ```
-            Exclude `kyma-system` namespace by adding `namespaceSelector`
-            ```yaml
-                namespaceSelector:
-                matchExpressions:
-                    - key: kubernetes.io/metadata.name
-                    operator: NotIn
-                    values:
-                        - "kyma-system"
-            ```
-        - Add exclusion of `kyma-system` namespace to `validationgwebhook`
-            ```bash
-                kubectl -n kyma-system edit validatingwebhookconfigurations ${HELM_RELEASE}-kube-prometheus-admission
-            ```
-            Exclude `kyma-system` namespace by adding `namespaceSelector`
-            ```yaml
-                namespaceSelector:
-                matchExpressions:
-                    - key: kubernetes.io/metadata.name
-                    operator: NotIn
-                    values:
-                        - "kyma-system"
-            ```
-        
+    >**Note:** If the `adminssion webhooks` are also being installed then these webhooks should exclude resources being installed in the `kyma-system` namespace. This can be done in the following way:
+    >    -  Add exclusion of `kyma-system` namespace to `mutatingwebhook`
+    >        ```bash
+    >           kubectl -n kyma-system edit mutatingwebhookconfigurations ${HELM_RELEASE}-kube-prometheus-admission
+    >        ```
+    >        Exclude `kyma-system` namespace by adding `namespaceSelector`
+    >        ```yaml
+    >            namespaceSelector:
+    >            matchExpressions:
+    >                - key: kubernetes.io/metadata.name
+    >                operator: NotIn
+    >                values:
+    >                    - "kyma-system"
+    >        ```
+    >   - Add exclusion of `kyma-system` namespace to `validationgwebhook`
+    >        ```bash
+    >         kubectl -n kyma-system edit validatingwebhookconfigurations ${HELM_RELEASE}-kube-prometheus-admission
+    >        ```
+    >        Exclude `kyma-system` namespace by adding `namespaceSelector`
+    >        ```yaml
+    >            namespaceSelector:
+    >            matchExpressions:
+    >                - key: kubernetes.io/metadata.name
+    >                operator: NotIn
+    >                values:
+    >                    - "kyma-system"
+    >        ```  
+
+       
 ### Activate scraping of Istio metrics & Grafana dashboards
 
 1. To configure Prometheus for scraping of the Istio-specific metrics from any istio-proxy running in the cluster, deploy a PodMonitor, which scrapes any Pod that has a port with name `.*-envoy-prom` exposed.

--- a/prometheus/README.md
+++ b/prometheus/README.md
@@ -60,33 +60,33 @@ The provided `values.yaml` covers the following adjustments:
 - Client certificate injection to support scraping of workload secured with Istio strict mTLS
 - Active scraping of workload annotated with prometheus.io/scrape
 
-3. If the `adminssion webhooks` are also being installed then these webhooks should exclude resources being installed in the `kyma-system` namespace. This can be done in the following way:
-  -  Add exclusion of `kyma-system` namespace to `mutatingwebhook`
-     ```bash
-        kubectl -n kyma-system edit mutatingwebhookconfigurations ${HELM_RELEASE}-kube-prometheus-admission
-     ```
-     Exclude `kyma-system` namespace by adding `namespaceSelector`
-     ```yaml
-         namespaceSelector:
-           matchExpressions:
-            - key: kubernetes.io/metadata.name
-              operator: NotIn
-              values:
-                - "kyma-system"
-     ```
-  - Add exclusion of `kyma-system` namespace to `validationgwebhook`
-    ```bash
-        kubectl -n kyma-system edit validatingwebhookconfigurations ${HELM_RELEASE}-kube-prometheus-admission
-     ```
-     Exclude `kyma-system` namespace by adding `namespaceSelector`
-     ```yaml
-         namespaceSelector:
-           matchExpressions:
-            - key: kubernetes.io/metadata.name
-              operator: NotIn
-              values:
-                - "kyma-system"
-     ```
+    >**Note** If the `adminssion webhooks` are also being installed then these webhooks should exclude resources being installed in the `kyma-system` namespace. This can be done in the following way:
+        -  Add exclusion of `kyma-system` namespace to `mutatingwebhook`
+            ```bash
+                kubectl -n kyma-system edit mutatingwebhookconfigurations ${HELM_RELEASE}-kube-prometheus-admission
+            ```
+            Exclude `kyma-system` namespace by adding `namespaceSelector`
+            ```yaml
+                namespaceSelector:
+                matchExpressions:
+                    - key: kubernetes.io/metadata.name
+                    operator: NotIn
+                    values:
+                        - "kyma-system"
+            ```
+        - Add exclusion of `kyma-system` namespace to `validationgwebhook`
+            ```bash
+                kubectl -n kyma-system edit validatingwebhookconfigurations ${HELM_RELEASE}-kube-prometheus-admission
+            ```
+            Exclude `kyma-system` namespace by adding `namespaceSelector`
+            ```yaml
+                namespaceSelector:
+                matchExpressions:
+                    - key: kubernetes.io/metadata.name
+                    operator: NotIn
+                    values:
+                        - "kyma-system"
+            ```
         
 ### Activate scraping of Istio metrics & Grafana dashboards
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- If admission webhooks are being installed for kube prometheus stack then these would interfere with the prometheusrules or other prometheus resources being created in `kyma-system` namespace. So add a exclusion for same.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
