### PR TITLE
Disable admission webhooks in Prometheus example

### DIFF
--- a/prometheus/README.md
+++ b/prometheus/README.md
@@ -60,7 +60,7 @@ The provided `values.yaml` covers the following adjustments:
 - Client certificate injection to support scraping of workload secured with Istio strict mTLS
 - Active scraping of workload annotated with prometheus.io/scrape
 
-    >**Note:** If the admission webhooks are also being installed, then these webhooks must exclude resources being installed in the `kyma-system` Namespace. This can be done in the following way:
+    >**Note:** The provided Helm values of this example disable the admission webhooks for the custom resource definitions of the kube-prometheus-stack. If the admission webhooks are also being installed (`prometheusOperator.admissionWebhooks.enabled=true`), then these webhooks must exclude resources being installed in the `kyma-system` Namespace. This can be done in the following way:
     >    -  Add exclusion of the `kyma-system` Namespace to mutating webhook:
     >        ```bash
     >           kubectl -n kyma-system edit mutatingwebhookconfigurations ${HELM_RELEASE}-kube-prometheus-admission
@@ -86,9 +86,9 @@ The provided `values.yaml` covers the following adjustments:
     >                operator: NotIn
     >                values:
     >                  - "kyma-system"
-    >        ```  
+    >        ```
 
-       
+
 ### Activate scraping of Istio metrics & Grafana dashboards
 
 1. To configure Prometheus for scraping of the Istio-specific metrics from any istio-proxy running in the cluster, deploy a PodMonitor, which scrapes any Pod that has a port with name `.*-envoy-prom` exposed.

--- a/prometheus/values.yaml
+++ b/prometheus/values.yaml
@@ -7,6 +7,10 @@ prometheusOperator:
   kubeletService:
     enabled: false
 
+  # disable admission webhooks to do not interfere with the Kyma monitoring stack
+  admissionWebhooks:
+    enabled: false
+
 # change the port of the node-export to be different from the one used by the Kyma monitoring stack
 prometheus-node-exporter:
   service:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

The admission webhooks of the kube-prometheus-stack can interfere with the Kyma monitoring stack. To avoid failures while deploying Kyma, the webhooks are disabled by default.

Changes proposed in this pull request:

- Disable admission webhooks for Prometheus example
- Adapt README

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
