### PR TITLE
fix cni problems in prometheus example

### DIFF
--- a/prometheus/values.yaml
+++ b/prometheus/values.yaml
@@ -10,6 +10,8 @@ prometheusOperator:
   # disable admission webhooks to do not interfere with the Kyma monitoring stack
   admissionWebhooks:
     enabled: false
+  tls:
+    enabled: false
 
 # change the port of the node-export to be different from the one used by the Kyma monitoring stack
 prometheus-node-exporter:
@@ -198,3 +200,9 @@ grafana:
       access: proxy
       jsonData:
         implementation: prometheus
+  sidecar:
+    securityContext:
+      privileged: false
+      runAsGroup: 1337
+      runAsNonRoot: true
+      runAsUser: 1337


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

The prometheus-operator is not starting up as the webhooks are disabled but still webhook tls cert injection is expected.
After fixing that, I fould that the grafana datasource sidecar is running as initContainer and faces connectivity problems with istio CNI. FIxed that as well by providing dedicated secutiry config.

Prometheus has an initContainer as well. However the traffic interception for the istio sidecar is disabled (only used for certificate injection), so there is no problem. Furthermore, there is no way to configure the securityContext for the container via the prometheus-operator, so I ignored that.

Changes proposed in this pull request:

- fix prometheus-operator startup problem by disabling webhook tls additional to the webhook
- add securitycontext for grafana initcontainer
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
