### PR TITLE
Use nodejs18 runtime in serverless examples

### DIFF
--- a/incluster_eventing/k8s-resources/emitter-fn.yaml
+++ b/incluster_eventing/k8s-resources/emitter-fn.yaml
@@ -6,7 +6,7 @@ metadata:
     name: event-emitter
     namespace: default
 spec:
-    runtime: nodejs16
+    runtime: nodejs18
     source:
       gitRepository: 
         url: https://github.com/kyma-project/examples.git

--- a/incluster_eventing/k8s-resources/receiver-fn.yaml
+++ b/incluster_eventing/k8s-resources/receiver-fn.yaml
@@ -6,7 +6,7 @@ metadata:
     name: event-receiver
     namespace: default
 spec:
-    runtime: nodejs16
+    runtime: nodejs18
     source:
       gitRepository: 
         url: https://github.com/kyma-project/examples.git

--- a/incluster_eventing/src/emitter-fn/config.yaml
+++ b/incluster_eventing/src/emitter-fn/config.yaml
@@ -1,6 +1,6 @@
 name: event-emitter
 namespace: default
-runtime: nodejs16
+runtime: nodejs18
 source:
     sourceType: git
     url: https://github.com/kwiatekus/examples.git

--- a/incluster_eventing/src/receiver-fn/config.yaml
+++ b/incluster_eventing/src/receiver-fn/config.yaml
@@ -1,6 +1,6 @@
 name: event-receiver
 namespace: default
-runtime: nodejs16
+runtime: nodejs18
 source:
     sourceType: git
     url: https://github.com/kwiatekus/examples.git


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Use latest nodejs v18 in the serverless examples

**Related issue(s)**
https://github.com/kyma-project/kyma/issues/16765