### PR TITLE
adjust OTEL demo to have proper protocols defined in the used k8s services

### DIFF
--- a/trace-demo/values.yaml
+++ b/trace-demo/values.yaml
@@ -25,12 +25,22 @@ components:
     envOverrides:
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
         value: 'http://telemetry-otlp-traces.kyma-system:4317'
+    service:
+      port: null
+    ports:
+      - name: grpc
+        value: 8080
 
   cartService:
     enabled: true
     envOverrides:
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
         value: 'http://telemetry-otlp-traces.kyma-system:4317'
+    service:
+      port: null
+    ports:
+      - name: grpc
+        value: 8080
     initContainers:
       - name: wait-for-redis
         image: busybox:latest
@@ -43,6 +53,11 @@ components:
     envOverrides:
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
         value: 'http://telemetry-otlp-traces.kyma-system:4317'
+    service:
+      port: null
+    ports:
+      - name: grpc
+        value: 8080
     initContainers:
       - name: wait-for-kafka
         image: busybox:latest
@@ -55,6 +70,11 @@ components:
     envOverrides:
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
         value: 'http://telemetry-otlp-traces.kyma-system:4317'
+    service:
+      port: null
+    ports:
+      - name: grpc
+        value: 8080
 
   emailService:
     enabled: true
@@ -63,6 +83,11 @@ components:
         value: 'http://telemetry-otlp-traces.kyma-system:4317'
       - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
         value: 'http://telemetry-otlp-traces.kyma-system:4318/v1/traces'
+    service:
+      port: null
+    ports:
+      - name: http
+        value: 8080
 
   featureflagService:
     enabled: true
@@ -96,6 +121,11 @@ components:
     envOverrides:
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
         value: 'http://telemetry-otlp-traces.kyma-system:4317'
+    service:
+      port: null
+    ports:
+      - name: http
+        value: 8080
 
   frontendProxy:
     enabled: true
@@ -111,24 +141,44 @@ components:
     envOverrides:
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
         value: 'http://telemetry-otlp-traces.kyma-system:4317'
+    service:
+      port: null
+    ports:
+      - name: grpc
+        value: 8080
 
   productCatalogService:
     enabled: true
     envOverrides:
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
         value: 'http://telemetry-otlp-traces.kyma-system:4317'
+    service:
+      port: null
+    ports:
+      - name: grpc
+        value: 8080
 
   quoteService:
     enabled: true
     envOverrides:
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
         value: 'telemetry-otlp-traces.kyma-system:4317'
+    service:
+      port: null
+    ports:
+      - name: http
+        value: 8080
 
   recommendationService:
     enabled: true
     envOverrides:
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
         value: 'http://telemetry-otlp-traces.kyma-system:4317'
+    service:
+      port: null
+    ports:
+      - name: grpc
+        value: 8080
 
   shippingService:
     enabled: true
@@ -137,6 +187,11 @@ components:
         value: 'http://telemetry-otlp-traces.kyma-system:4317'
       - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
         value: 'http://telemetry-otlp-traces.kyma-system:4317'
+    service:
+      port: null
+    ports:
+      - name: grpc
+        value: 8080
 
   ffsPostgres:
     enabled: true

--- a/trace-demo/values.yaml
+++ b/trace-demo/values.yaml
@@ -7,6 +7,14 @@ prometheus:
 grafana:
   enabled: false
 
+default:
+  envOverrides:
+  - name: OTEL_SERVICE_NAME
+    valueFrom:
+      fieldRef:
+        apiVersion: v1
+        fieldPath: "metadata.labels['app.kubernetes.io/name']"
+
 components:
   accountingService:
     enabled: true


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

For specific features of istio, istio must have a chance to determine the protocol supported by an exposed port. For that it uses naming conventions like "http-metrics" for a service port, or it uses the "appProtocol" attribute of a service port.

In the otel-demo app the name of the services is set to "tcp-service" and no appProtocol is defined. With that it cannot determine the protocol and no spans are created at all for most of the communication happening.

As a workaround I overwrote the port definitions to set a name explicit. Later on we should contribute to upstream to simply set the protocol per service.


Changes proposed in this pull request:

- overwriting most service port names with the appropriate protocol prefix to make istio behave proper
- using the "app.kubernetes.io/name" label as service name to be aligned with istio conventions
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
