### PR TITLE
use custom prometheus for kiali example

### DIFF
--- a/kiali/README.md
+++ b/kiali/README.md
@@ -8,7 +8,7 @@ The following instructions outline how to install [`Kiali`](https://github.com/k
 
 - Kyma as the target deployment runtime
 - A [Prometheus instance preserving Istio metrics](./../prometheus/) deployed to the runtime.
-- kubectl > 1.26.x
+- kubectl version 1.26.x or higher
 - Helm 3.x
 
 ## Installation

--- a/kiali/README.md
+++ b/kiali/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The following instructions outline how to install [`Kiali`](https://github.com/kiali/helm-charts/tree/master/kiali-operator) in Kyma. Because Kiali needs a Prometheus installation preserving Istio metrics, this example assumes that you installed the [custom Prometheus example](./../prometheus/).
+The following instructions outline how to install [`Kiali`](https://github.com/kiali/helm-charts/tree/master/kiali-operator) in Kyma.
 
 ## Prerequisites
 

--- a/kiali/README.md
+++ b/kiali/README.md
@@ -2,12 +2,12 @@
 
 ## Overview
 
-The following instructions outline how to install [`Kiali`](https://github.com/kiali/helm-charts/tree/master/kiali-operator) in Kyma. As Kiali requires a prometheus installation preserving istio metrics, this example assumes that you installed the [custom prometheus example](./../prometheus/).
+The following instructions outline how to install [`Kiali`](https://github.com/kiali/helm-charts/tree/master/kiali-operator) in Kyma. Because Kiali needs a Prometheus installation preserving Istio metrics, this example assumes that you installed the [custom Prometheus example](./../prometheus/).
 
 ## Prerequisites
 
 - Kyma as the target deployment runtime
-- A [prometheus instance preserving istio metrics](./../prometheus/) deployed to the runtime
+- A [Prometheus instance preserving Istio metrics](./../prometheus/) deployed to the runtime.
 - kubectl > 1.26.x
 - Helm 3.x
 

--- a/kiali/README.md
+++ b/kiali/README.md
@@ -2,12 +2,13 @@
 
 ## Overview
 
-The following instructions outline how to install [`Kiali`](https://github.com/kiali/helm-charts/tree/master/kiali-operator) in Kyma.
+The following instructions outline how to install [`Kiali`](https://github.com/kiali/helm-charts/tree/master/kiali-operator) in Kyma. As Kiali requires a prometheus installation preserving istio metrics, this example assumes that you installed the [custom prometheus example](./../prometheus/).
 
 ## Prerequisites
 
-- Kyma as the target deployment environment
-- kubectl > 1.22.x
+- Kyma as the target deployment runtime
+- A [prometheus instance preserving istio metrics](./../prometheus/) deployed to the runtime
+- kubectl > 1.26.x
 - Helm 3.x
 
 ## Installation
@@ -38,7 +39,8 @@ The following instructions outline how to install [`Kiali`](https://github.com/k
 
 Run the Helm upgrade command, which installs the chart if not present yet.
 ```bash
-helm upgrade --install --create-namespace -n $KYMA_NS $HELM_KIALI_RELEASE kiali/kiali-operator -f https://raw.githubusercontent.com/kyma-project/examples/main/kiali/values.yaml
+export PROM_SERVICE_NAME=$(kubectl -n ${KYMA_NS} get service -l app=kube-prometheus-stack-prometheus -ojsonpath='{.items[*].metadata.name}')
+helm upgrade --install --create-namespace -n $KYMA_NS $HELM_KIALI_RELEASE kiali/kiali-operator -f https://raw.githubusercontent.com/kyma-project/examples/main/kiali/values.yaml --set cr.spec.external_services.prometheus.url=http://$PROM_SERVICE_NAME.$KYMA_NS:9090
 ```
 
 You can either use the [`values.yaml`](./values.yaml) provided in this `kiali` folder, which contains customized settings deviating from the default settings, or create your own `values.yaml` file.

--- a/kiali/values.yaml
+++ b/kiali/values.yaml
@@ -2,6 +2,9 @@ cr:
   create: true
   name: kiali-server
   spec:
+    auth:
+      # configure the authentication strategy
+      # strategy: token | anonymous | header | ..
     server:
       observability:
         tracing:
@@ -34,7 +37,8 @@ cr:
       grafana:
         enabled: false
       prometheus:
-        url: "http://monitoring-prometheus.kyma-system:9090"
+      # set prometheus url via command line args
+      #  url: ""
       tracing:
         enabled: false
     kiali_feature_flags:

--- a/prometheus/values.yaml
+++ b/prometheus/values.yaml
@@ -44,7 +44,6 @@ prometheus:
       labels:
         sidecar.istio.io/inject: "true"
       annotations:
-        traffic.sidecar.istio.io/includeInboundPorts: ""   # do not intercept any inbound ports
         traffic.sidecar.istio.io/includeOutboundIPRanges: ""  # do not intercept any outbound traffic
         proxy.istio.io/config: |
           # configure an env variable `OUTPUT_CERTS` to write certificates to the given folder
@@ -200,3 +199,5 @@ grafana:
       runAsGroup: 1337
       runAsNonRoot: true
       runAsUser: 1337
+  podLabels:
+    sidecar.istio.io/inject: "true"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- switch to custom prometheus instead of deprecated built-in solution
- enable istio sidecar for incoming traffic to prometheus to allow secure communication by kiali
- enable istio for grafana to have secure communication to prometheus

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
