### PR TITLE
Add Telemetry module as a prerequisite for observability examples

### DIFF
--- a/jaeger/README.md
+++ b/jaeger/README.md
@@ -7,7 +7,7 @@ The following instructions outline how to use [`Jaeger`](https://github.com/jaeg
 ## Prerequisites
 
 - Kyma version 2.10 or higher as the target deployment environment
-- Ensure that the [Telemetry module](https://kyma-project.io/#/telemetry-manager/user/README) is [installed](https://kyma-project.io/#/02-get-started/08-install-uninstall-upgrade-kyma-module?id=install-kyma-with-a-module)
+- Ensure that the [Telemetry module](https://kyma-project.io/#/telemetry-manager/user/README) is [installed](https://kyma-project.io/#/02-get-started/08-install-uninstall-upgrade-kyma-module?id=install-uninstall-and-upgrade-kyma-with-a-module)
 - kubectl version 1.22.x or higher
 - Helm 3.x
 

--- a/jaeger/README.md
+++ b/jaeger/README.md
@@ -7,7 +7,7 @@ The following instructions outline how to use [`Jaeger`](https://github.com/jaeg
 ## Prerequisites
 
 - Kyma version 2.10 or higher as the target deployment environment
-- Ensure that the [Telemetry module](https://kyma-project.io/#/telemetry-manager/user/README) is [installed](https://kyma-project.io/#/02-get-started/08-install-uninstall-upgrade-kyma-module?id=install-uninstall-and-upgrade-kyma-with-a-module)
+- The [Telemetry module](https://kyma-project.io/#/telemetry-manager/user/README) is [installed](https://kyma-project.io/#/02-get-started/08-install-uninstall-upgrade-kyma-module?id=install-uninstall-and-upgrade-kyma-with-a-module)
 - kubectl version 1.22.x or higher
 - Helm 3.x
 

--- a/jaeger/README.md
+++ b/jaeger/README.md
@@ -7,6 +7,7 @@ The following instructions outline how to use [`Jaeger`](https://github.com/jaeg
 ## Prerequisites
 
 - Kyma version 2.10 or higher as the target deployment environment
+- Ensure that the [Telemetry module](https://kyma-project.io/#/telemetry-manager/user/README) is [installed](https://kyma-project.io/#/02-get-started/08-install-uninstall-upgrade-kyma-module?id=install-kyma-with-a-module)
 - kubectl version 1.22.x or higher
 - Helm 3.x
 

--- a/loki/README.md
+++ b/loki/README.md
@@ -17,7 +17,7 @@ The following instructions outline how to use [`Loki`](https://github.com/grafan
 ## Prerequisites
 
 - Kyma as the target deployment environment
-- Ensure that the [Telemetry module](https://kyma-project.io/#/telemetry-manager/user/README) is [installed](https://kyma-project.io/#/02-get-started/08-install-uninstall-upgrade-kyma-module?id=install-uninstall-and-upgrade-kyma-with-a-module)
+- The [Telemetry module](https://kyma-project.io/#/telemetry-manager/user/README) is [installed](https://kyma-project.io/#/02-get-started/08-install-uninstall-upgrade-kyma-module?id=install-uninstall-and-upgrade-kyma-with-a-module)
 - Kubectl version 1.22.x or higher
 - Helm 3.x
 

--- a/loki/README.md
+++ b/loki/README.md
@@ -17,7 +17,7 @@ The following instructions outline how to use [`Loki`](https://github.com/grafan
 ## Prerequisites
 
 - Kyma as the target deployment environment
-- Ensure that the [Telemetry module](https://kyma-project.io/#/telemetry-manager/user/README) is [installed](https://kyma-project.io/#/02-get-started/08-install-uninstall-upgrade-kyma-module?id=install-kyma-with-a-module)
+- Ensure that the [Telemetry module](https://kyma-project.io/#/telemetry-manager/user/README) is [installed](https://kyma-project.io/#/02-get-started/08-install-uninstall-upgrade-kyma-module?id=install-uninstall-and-upgrade-kyma-with-a-module)
 - Kubectl version 1.22.x or higher
 - Helm 3.x
 

--- a/loki/README.md
+++ b/loki/README.md
@@ -17,9 +17,9 @@ The following instructions outline how to use [`Loki`](https://github.com/grafan
 ## Prerequisites
 
 - Kyma as the target deployment environment
+- Ensure that the [Telemetry module](https://kyma-project.io/#/telemetry-manager/user/README) is [installed](https://kyma-project.io/#/02-get-started/08-install-uninstall-upgrade-kyma-module?id=install-kyma-with-a-module)
 - Kubectl version 1.22.x or higher
 - Helm 3.x
-
 
 ## Preparation
 

--- a/trace-demo/README.md
+++ b/trace-demo/README.md
@@ -7,7 +7,7 @@ The following instructions install the OpenTelemetry [demo application](https://
 ## Prerequisites
 
 - Kyma as the target deployment environment
-- Ensure that the [Telemetry module](https://kyma-project.io/#/telemetry-manager/user/README) is [installed](https://kyma-project.io/#/02-get-started/08-install-uninstall-upgrade-kyma-module?id=install-kyma-with-a-module)
+- Ensure that the [Telemetry module](https://kyma-project.io/#/telemetry-manager/user/README) is [installed](https://kyma-project.io/#/02-get-started/08-install-uninstall-upgrade-kyma-module?id=install-uninstall-and-upgrade-kyma-with-a-module)
 - kubectl version 1.22.x or higher
 - Helm 3.x
 

--- a/trace-demo/README.md
+++ b/trace-demo/README.md
@@ -7,7 +7,7 @@ The following instructions install the OpenTelemetry [demo application](https://
 ## Prerequisites
 
 - Kyma as the target deployment environment
-- Ensure that the [Telemetry module](https://kyma-project.io/#/telemetry-manager/user/README) is [installed](https://kyma-project.io/#/02-get-started/08-install-uninstall-upgrade-kyma-module?id=install-uninstall-and-upgrade-kyma-with-a-module)
+- The [Telemetry module](https://kyma-project.io/#/telemetry-manager/user/README) is [installed](https://kyma-project.io/#/02-get-started/08-install-uninstall-upgrade-kyma-module?id=install-uninstall-and-upgrade-kyma-with-a-module)
 - kubectl version 1.22.x or higher
 - Helm 3.x
 

--- a/trace-demo/README.md
+++ b/trace-demo/README.md
@@ -6,7 +6,8 @@ The following instructions install the OpenTelemetry [demo application](https://
 
 ## Prerequisites
 
-- Kyma with the [Telemetry module](https://kyma-project.io/#/telemetry-manager/user/README) installed
+- Kyma as the target deployment environment
+- Ensure that the [Telemetry module](https://kyma-project.io/#/telemetry-manager/user/README) is [installed](https://kyma-project.io/#/02-get-started/08-install-uninstall-upgrade-kyma-module?id=install-kyma-with-a-module)
 - kubectl version 1.22.x or higher
 - Helm 3.x
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- add a prerequisite to ensure that the Telemetry module is enabled for the following examples: `jaeger`, `loki` and `trace-demo`

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
kyma-project/kyma#18190