### PR TITLE
Add default persistence settings to prometheus example

### DIFF
--- a/kiali/README.md
+++ b/kiali/README.md
@@ -81,7 +81,7 @@ To see the service communication visualized in Kiali, follow the instructions in
 
 If you use [Jaeger](https://www.jaegertracing.io/) for distributed tracing, Kiali can use your Jaeger instance to [provide traces](https://kiali.io/docs/features/tracing/).
 
-For integration instructions, read [Kiali: Jaeger configuration](https://kiali.io/docs/configuration/p8s-jaeger-grafana/jaeger/).
+For integration instructions, read [Kiali: Jaeger configuration](https://kiali.io/docs/configuration/p8s-jaeger-grafana/tracing/jaeger/).
 
 ### Integrate Grafana
 

--- a/prometheus/README.md
+++ b/prometheus/README.md
@@ -59,6 +59,8 @@ The provided `values.yaml` covers the following adjustments:
 - Parallel operation to a Kyma monitoring stack
 - Client certificate injection to support scraping of workload secured with Istio strict mTLS
 - Active scraping of workload annotated with prometheus.io/scrape
+- Basic configuration of data persistence with retention
+- Basic resource limits for involved components
 
 ### Activate scraping of Istio metrics & Grafana dashboards
 

--- a/prometheus/values.yaml
+++ b/prometheus/values.yaml
@@ -7,6 +7,15 @@ prometheusOperator:
   kubeletService:
     enabled: false
 
+  # Define resource limits
+  resources:
+    requests:
+      cpu: "10m"
+      memory: "128Mi"
+    limits:
+      cpu: "500m"
+      memory: "1Gi"
+
 # change the port of the node-exporter to be different from the one used by the Kyma monitoring stack
 prometheus-node-exporter:
   service:
@@ -18,6 +27,15 @@ prometheus-node-exporter:
 
 kube-state-metrics:
   prometheusScrape: false
+
+  # Define resource limits
+  resources:
+    requests:
+      cpu: "10m"
+      memory: "128Mi"
+    limits:
+      cpu: "500m"
+      memory: "2Gi"
 
 ####### This block disables control plane components which are not reachable from within the Gardener data plane
 
@@ -61,6 +79,30 @@ prometheus:
     volumeMounts:
       - mountPath: /etc/prometheus/secrets/istio.default/
         name: istio-certs
+
+####### This block configures data retention and persistence
+    # How long to retain metrics
+    retention: 30d
+
+    # Maximum size of metrics
+    retentionSize: 25GB
+
+    # Use a persistent volume for durable storage of data
+    storageSpec:
+      volumeClaimTemplate:
+        spec:
+          resources:
+            requests:
+              storage: 30Gi
+    
+    # Define resource limits
+    resources:
+      limits:
+        cpu: 1000m
+        memory: 4Gi
+      requests:
+        cpu: 125m
+        memory: 256m
 
 ####### This block is needed to also use ServiceMonitors, which are not deployed as part of the chart
 
@@ -185,6 +227,7 @@ prometheus:
             action: replace
             target_label: node
 
+# Configures grafana with istio sidecar and alertmanage as additional datasource
 grafana:
   additionalDataSources:
     - name: Alertmanager

--- a/prometheus/values.yaml
+++ b/prometheus/values.yaml
@@ -244,3 +244,10 @@ grafana:
       runAsUser: 1337
   podLabels:
     sidecar.istio.io/inject: "true"
+  serviceMonitor:
+    scheme: https
+    tlsConfig:
+      caFile: /etc/prometheus/secrets/istio.default/root-cert.pem
+      certFile: /etc/prometheus/secrets/istio.default/cert-chain.pem
+      insecureSkipVerify: true
+      keyFile: /etc/prometheus/secrets/istio.default/key.pem


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

The example used in-memory persistence to keep it lightweight. Indeed, it is better to have persistence enabled by default  based on PVCs as usual for a typical in-cluster setup
Changes proposed in this pull request:

- configured retention times for data by time and size
- configured persistency by PVC
- configured resource setting for all relevant components
- fixed grafana serviceMonitor

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
