### PR TITLE
fix: Allow createSecret job to create secrets when istio is enabled

### DIFF
--- a/prometheus/values.yaml
+++ b/prometheus/values.yaml
@@ -2,6 +2,10 @@
 ####### This block configures resource limits for the tooling and disables scaping of them via annotations
 
 prometheusOperator:
+  admissionWebhooks:
+    patch:
+      podAnnotations:
+        sidecar.istio.io/inject: "false"
   # Define resource limits
   resources:
     requests:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- When istio is enabled the createSecret Job fails. The injected side car prevents it. So exclude istio injection here.
-  More info: https://github.com/prometheus-community/helm-charts/issues/479
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
